### PR TITLE
Add FastAPI + Motor example

### DIFF
--- a/mongo_fastapi/README.md
+++ b/mongo_fastapi/README.md
@@ -1,0 +1,9 @@
+This example demonstrates how to expose categories stored in MongoDB via FastAPI.
+
+Run with:
+
+```
+uvicorn mongo_fastapi.main:app
+```
+
+The `/categories` endpoint returns categories with nested subcategories and the first few product names for each subcategory.

--- a/mongo_fastapi/db.py
+++ b/mongo_fastapi/db.py
@@ -1,0 +1,13 @@
+from motor.motor_asyncio import AsyncIOMotorClient
+from functools import lru_cache
+
+class Settings:
+    mongo_uri: str = "mongodb://localhost:27017"
+    db_name: str = "parser"
+
+@lru_cache()
+def get_client() -> AsyncIOMotorClient:
+    return AsyncIOMotorClient(Settings().mongo_uri)
+
+def get_db():
+    return get_client()[Settings().db_name]

--- a/mongo_fastapi/main.py
+++ b/mongo_fastapi/main.py
@@ -1,0 +1,24 @@
+from typing import List
+from fastapi import FastAPI, Depends
+
+from .db import get_db
+from .schemas import CategoryTree, CategoryWithProducts
+
+app = FastAPI(title="Category API")
+
+@app.get("/categories", response_model=List[CategoryTree])
+async def list_categories(db=Depends(get_db)):
+    """Return categories with nested subcategories and product names."""
+    result: List[CategoryTree] = []
+    cursor = db["categories"].find({"parent_id": None})
+    async for cat in cursor:
+        sub_cats: List[CategoryWithProducts] = []
+        sub_cursor = db["categories"].find({"parent_id": cat["_id"]})
+        async for sub in sub_cursor:
+            products = await db["products"].find({"category_id": sub["_id"]}).to_list(10)
+            sub_cats.append(CategoryWithProducts(
+                **sub,
+                products=[p["name"] for p in products]
+            ))
+        result.append(CategoryTree(**cat, subcategories=sub_cats))
+    return result

--- a/mongo_fastapi/schemas.py
+++ b/mongo_fastapi/schemas.py
@@ -1,0 +1,47 @@
+from typing import List, Optional
+from pydantic import BaseModel, Field
+from bson import ObjectId
+
+class PyObjectId(ObjectId):
+    @classmethod
+    def __get_validators__(cls):
+        yield cls.validate
+
+    @classmethod
+    def validate(cls, v):
+        if not ObjectId.is_valid(v):
+            raise ValueError("Invalid ObjectId")
+        return ObjectId(v)
+
+    @classmethod
+    def __modify_schema__(cls, field_schema):
+        field_schema.update(type="string")
+
+class ProductOut(BaseModel):
+    id: PyObjectId = Field(alias="_id")
+    name: str
+
+    class Config:
+        json_encoders = {ObjectId: str}
+        populate_by_name = True
+        arbitrary_types_allowed = True
+
+class CategoryWithProducts(BaseModel):
+    id: PyObjectId = Field(alias="_id")
+    name: str
+    products: List[str]
+
+    class Config:
+        json_encoders = {ObjectId: str}
+        populate_by_name = True
+        arbitrary_types_allowed = True
+
+class CategoryTree(BaseModel):
+    id: PyObjectId = Field(alias="_id")
+    name: str
+    subcategories: List[CategoryWithProducts]
+
+    class Config:
+        json_encoders = {ObjectId: str}
+        populate_by_name = True
+        arbitrary_types_allowed = True


### PR DESCRIPTION
## Summary
- provide example FastAPI service that fetches categories from MongoDB
- document how to run it

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6859ae1e54b083208ce8df5fadfee19d